### PR TITLE
support etherscan.io compatible /address/0x... url

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -119,7 +119,7 @@ BlocksApp.config(['$stateProvider', '$urlRouterProvider', function($stateProvide
             }
         })
         .state('address', {
-            url: "/addr/{hash}",
+            url: "/addr{dummy:(?:ess)?}/{hash}",
             templateUrl: "views/address.html",
             data: {pageTitle: 'Address'},
             controller: "AddressController",


### PR DESCRIPTION
support both `/addr/0x...` and `/address/0x...` urls