### PR TITLE
Changing mongo install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Install mongodb:
 
 MacOS: `brew install mongodb`
 
-Ubuntu: `sudo apt-get install -y mongodb-org`
+Ubuntu: `sudo apt-get install -y mongodb`
 
 ## Populate the DB
 


### PR DESCRIPTION
`sudo apt-get install -y mongodb-org ` produce `E: Unable to locate package mongodb-org` in ubuntu
 but now sudo apt install -y mongodb can directly install the mongodb without any error